### PR TITLE
Improve planner persistence

### DIFF
--- a/app/components/planung/Budget.tsx
+++ b/app/components/planung/Budget.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 interface BudgetPosten {
   kategorie: string;
@@ -8,14 +9,19 @@ interface BudgetPosten {
   notiz: string;
 }
 
+const DEFAULT_POSTEN: BudgetPosten[] = [
+  { kategorie: "Location", geplant: 3000, kosten: 0, bezahlt: false, notiz: "inkl. Essen/Trinken" },
+  { kategorie: "Musik/DJ", geplant: 800, kosten: 0, bezahlt: false, notiz: "" },
+  { kategorie: "Fotograf", geplant: 1200, kosten: 0, bezahlt: false, notiz: "" },
+  { kategorie: "Kleidung", geplant: 1500, kosten: 0, bezahlt: false, notiz: "Braut & Bräutigam" },
+  { kategorie: "Deko/Blumen", geplant: 600, kosten: 0, bezahlt: false, notiz: "" },
+];
+
 export default function Budget() {
-  const [posten, setPosten] = useState<BudgetPosten[]>([
-    { kategorie: "Location", geplant: 3000, kosten: 0, bezahlt: false, notiz: "inkl. Essen/Trinken" },
-    { kategorie: "Musik/DJ", geplant: 800, kosten: 0, bezahlt: false, notiz: "" },
-    { kategorie: "Fotograf", geplant: 1200, kosten: 0, bezahlt: false, notiz: "" },
-    { kategorie: "Kleidung", geplant: 1500, kosten: 0, bezahlt: false, notiz: "Braut & Bräutigam" },
-    { kategorie: "Deko/Blumen", geplant: 600, kosten: 0, bezahlt: false, notiz: "" },
-  ]);
+  const [posten, setPosten] = useLocalStorage<BudgetPosten[]>(
+    "budget_posten",
+    DEFAULT_POSTEN
+  );
   const [neu, setNeu] = useState<BudgetPosten>({ kategorie: "", geplant: 0, kosten: 0, bezahlt: false, notiz: "" });
 
   const addPosten = () => {
@@ -146,6 +152,13 @@ export default function Budget() {
           </tfoot>
         </table>
       </div>
+      <button
+        className="btn"
+        type="button"
+        onClick={() => setPosten(DEFAULT_POSTEN)}
+      >
+        Budget zurücksetzen
+      </button>
     </div>
   );
 }

--- a/app/components/planung/Checklisten.tsx
+++ b/app/components/planung/Checklisten.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 interface Task {
   text: string;
@@ -8,7 +9,7 @@ interface Task {
   notiz: string;
 }
 
-const defaultKategorien = [
+const DEFAULT_KATEGORIEN = [
   "Vor der Hochzeit",
   "Zeremonie",
   "Feier",
@@ -17,15 +18,21 @@ const defaultKategorien = [
 ];
 
 export default function Checklisten() {
-  const [tasks, setTasks] = useState<Task[]>([
-    { text: "Location buchen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
-    { text: "DJ/Liveband anfragen", erledigt: false, kategorie: "Feier", faellig: "", notiz: "" },
-    { text: "Ringe besorgen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
-    { text: "Brautkleid aussuchen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
-    { text: "Danksagungen vorbereiten", erledigt: false, kategorie: "Nach der Hochzeit", faellig: "", notiz: "" },
-  ]);
-  const [neu, setNeu] = useState<Task>({ text: "", erledigt: false, kategorie: defaultKategorien[0], faellig: "", notiz: "" });
-  const [kategorien, setKategorien] = useState<string[]>(defaultKategorien);
+  const [tasks, setTasks] = useLocalStorage<Task[]>(
+    "check_tasks",
+    [
+      { text: "Location buchen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
+      { text: "DJ/Liveband anfragen", erledigt: false, kategorie: "Feier", faellig: "", notiz: "" },
+      { text: "Ringe besorgen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
+      { text: "Brautkleid aussuchen", erledigt: false, kategorie: "Vor der Hochzeit", faellig: "", notiz: "" },
+      { text: "Danksagungen vorbereiten", erledigt: false, kategorie: "Nach der Hochzeit", faellig: "", notiz: "" },
+    ]
+  );
+  const [neu, setNeu] = useState<Task>({ text: "", erledigt: false, kategorie: DEFAULT_KATEGORIEN[0], faellig: "", notiz: "" });
+  const [kategorien, setKategorien] = useLocalStorage<string[]>(
+    "check_kategorien",
+    DEFAULT_KATEGORIEN
+  );
   const [neueKategorie, setNeueKategorie] = useState("");
 
   const addTask = () => {
@@ -138,6 +145,16 @@ export default function Checklisten() {
           </tbody>
         </table>
       </div>
+      <button
+        className="btn"
+        type="button"
+        onClick={() => {
+          setTasks([]);
+          setKategorien(DEFAULT_KATEGORIEN);
+        }}
+      >
+        Liste zurücksetzen
+      </button>
     </div>
   );
 }

--- a/app/hooks/useLocalStorage.ts
+++ b/app/hooks/useLocalStorage.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage<T>(key: string, initial: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return initial;
+    try {
+      const stored = localStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : initial;
+    } catch {
+      return initial;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      // ignore write errors
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
## Summary
- add generic `useLocalStorage` hook
- persist budget entries locally and allow reset
- persist checklist tasks and categories locally and allow reset

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_683f7c658c048320b06f5da94b5e33ab