### PR TITLE
Implement guest list persistence

### DIFF
--- a/app/components/planung/Gaeste.tsx
+++ b/app/components/planung/Gaeste.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocalStorage } from "../../hooks/useLocalStorage";
 
 interface Gast {
   name: string;
@@ -8,8 +9,11 @@ interface Gast {
 }
 
 export default function Gaeste() {
-  const [gaeste, setGaeste] = useState<Gast[]>([]);
-  const [tische, setTische] = useState<string[]>(["Tisch 1", "Tisch 2"]);
+  const [gaeste, setGaeste] = useLocalStorage<Gast[]>("gaeste_liste", []);
+  const [tische, setTische] = useLocalStorage<string[]>(
+    "gaeste_tische",
+    ["Tisch 1", "Tisch 2"]
+  );
   const [neuGast, setNeuGast] = useState<Gast>({ name: "", seite: "Beide", besonderheiten: "", tisch: tische[0] });
   const [neuTisch, setNeuTisch] = useState("");
 


### PR DESCRIPTION
## Summary
- persist guest and table data in localStorage for the "Gästeliste & Sitzordnung" module

## Testing
- `npm install` *(fails: unable to fetch packages)*
- `npm run typecheck` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683f855b98d88320ad4e01af6418b7fe